### PR TITLE
fix infinite loop caused by illegal token

### DIFF
--- a/src/parser/tokenizer.rs
+++ b/src/parser/tokenizer.rs
@@ -91,10 +91,10 @@ impl Tokenizer {
                     };
                 }
 
-                return Token {
+                Token {
                     value: String::from(self.char),
                     t_type: TokenEnum::ILLEGAL,
-                };
+                }
             }
         };
 


### PR DESCRIPTION
remove early return for illegal token

the return statement (for the illegal token) introduced an early exit preventing the tokenizer from moving/reading the next character and thus the values sent to the parser did not include an EOF(end of file) token.

because of this, the parser could not exit because the was no EOF token.