### PR TITLE
Fix text shadow and outline scaling

### DIFF
--- a/src/widgets/activity_viewer.rs
+++ b/src/widgets/activity_viewer.rs
@@ -360,6 +360,11 @@ impl ActivityViewer {
         let sm = imp.slide_manager.borrow();
         self.set_background_image(img);
 
+        if sm.slides().is_empty() {
+            let slide = sm.make_new_slide();
+            self.imp().listview.borrow().append_item(&slide);
+        }
+
         for slide in sm.slides() {
             let Some(canvas) = slide.canvas() else {
                 continue;

--- a/src/widgets/canvas/serialise.rs
+++ b/src/widgets/canvas/serialise.rs
@@ -124,7 +124,7 @@ impl SlideData {
                 font_size: 16.0,
                 justification: 1,
                 align: 1,
-                text_outline: false,
+                text_outline: true,
                 text_shadow: true,
             }
         };

--- a/src/widgets/canvas/text_item.rs
+++ b/src/widgets/canvas/text_item.rs
@@ -221,17 +221,28 @@ mod imp {
 
             let font_css = obj.get_font_css(obj.font(), converted_font_size);
 
+            let ratio = canvas.current_ratio();
             let outline = if obj.text_outline() {
-                "#000 -1px -1px 1px, 
-                #000 1px -1px 1px, 
-                #000 -1px  1px 1px,
-                #000 1px  1px 1px"
+                let offset = 3.0 * ratio;
+                let radius = 1.0 * ratio;
+                &format!(
+                    "#000 {} #000 {} #000 {} #000 {}",
+                    format!("-{}px -{}px {}px,", offset, offset, radius),
+                    format!("{}px -{}px {}px,", offset, offset, radius),
+                    format!("-{}px  {}px {}px,", offset, offset, radius),
+                    format!("{}px {}px {}px", offset, offset, radius)
+                )
             } else {
                 "#0000 0px  0px 0px"
             };
 
             let shadow = if obj.text_shadow() {
-                &format!("{outline}, -2px 2px 1px black")
+                &format!(
+                    "{outline}, -{}px {}px {}px black",
+                    8.0 * ratio,
+                    8.0 * ratio,
+                    12.0 * ratio
+                )
             } else {
                 outline
             };
@@ -242,8 +253,10 @@ mod imp {
                     color: white;
                     padding: 0px;
                     background: 0;
+                    letter-spacing: {}px;
                     text-shadow: {shadow};
                 }}",
+                2.0 * ratio
             );
 
             css

--- a/src/widgets/message_alert.rs
+++ b/src/widgets/message_alert.rs
@@ -208,12 +208,10 @@ impl MessageAlert {
                 }
 
                 if obj.imp().request_next_message.get()
-                    && let Some(point) =
-                        // obj.imp().back_spacer.translate_coordinates(&sw, 0.0, 0.0)
-                        obj
-                            .imp()
-                            .back_spacer
-                            .compute_point(&sw, &gtk::graphene::Point::new(0.0, 0.0))
+                    && let Some(point) = obj
+                        .imp()
+                        .back_spacer
+                        .compute_point(&sw, &gtk::graphene::Point::new(0.0, 0.0))
                 {
                     let space = point.x() - sw.width() as f32;
 


### PR DESCRIPTION
Applied canvas current ratio (scale) to the shadow and outline values to allow scaling values.
Enabled default text outline for readability

Also fix displaying background if no slide is loaded (side-quest).

resolve #57 