### PR TITLE
fix removing slide in editor

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -32,7 +32,7 @@ mod imp {
             Properties,
             object::CastNone,
             subclass::{
-                object::{ObjectImpl, ObjectImplExt},
+                object::ObjectImpl,
                 types::{ObjectSubclass, ObjectSubclassExt},
             },
         },

--- a/src/notepad.rs
+++ b/src/notepad.rs
@@ -14,8 +14,8 @@ use gtk::glib::prelude::*;
 use gtk::glib::subclass::types::ObjectSubclassIsExt;
 use gtk::prelude::{
     AccessibleExt, AdjustmentExt, BoxExt, ButtonExt, DialogExt, GtkApplicationExt, GtkWindowExt,
-    ScrollableExt, SnapshotExt, StyleContextExt, TextBufferExt, TextViewExt, WidgetExt,
-    WidgetExtManual,
+    OrientableExt, ScrollableExt, SnapshotExt, StyleContextExt, TextBufferExt, TextViewExt,
+    WidgetExt, WidgetExtManual,
 };
 use gtk::subclass::window;
 use gtk::{CssProvider, pango};
@@ -78,14 +78,15 @@ pub fn init_app() {
         gtk::gio::ApplicationFlags::FLAGS_NONE,
     );
     app.set_resource_base_path(Some(app_config::RESOURCE_PATH));
+    app.set_register_session(true);
 
     // app.connect_activate(build_ui);
     app.connect_activate(|app| {
         {
             // let win = SettingsWindow::new();
-            let win = SongEditWindow::new();
-            app.add_window(&win);
-            win.show(None);
+            // let win = SongEditWindow::new();
+            // app.add_window(&win);
+            // win.show(None);
         }
         {
             // let win = gtk::Window::new();
@@ -95,7 +96,7 @@ pub fn init_app() {
             // win.present();
         }
 
-        // let _ = build_ui(app);
+        let _ = build_ui(app);
         // build_dnd_ui(&app);
     });
 
@@ -283,9 +284,23 @@ fn build_ui(app: &impl IsA<gtk::Application>) -> impl IsA<gtk::Window> {
 
         let notify_btn = gtk::Button::with_label("Notify");
         t_box.append(&notify_btn);
-        let a = gtk::DropDown::from_strings(&["1", "2", "3"]);
+        let a = gtk::SpinButton::with_range(0.0, 360.0, 1.0);
+        a.connect_value_changed({
+            let sm = sm.clone();
+            move |btn| {
+                let Some(canvas) = sm.current_slide().and_then(|v| v.canvas()) else {
+                    return;
+                };
+
+                let Some(ti) = canvas.widget().get_children::<TextItem>().next() else {
+                    return;
+                };
+                let ci = ti.clone().upcast::<CanvasItem>();
+                ci.imp().rotation.set(btn.value());
+                ti.style();
+            }
+        });
         t_box.append(&a);
-        a.set_selected(2);
 
         notify_btn.connect_clicked({
             move |btn| {

--- a/src/services/slide.rs
+++ b/src/services/slide.rs
@@ -7,13 +7,9 @@ use crate::widgets::canvas::canvas_item::{CanvasItem, CanvasItemExt};
 use crate::widgets::canvas::serialise::{CanvasData, SlideData};
 use crate::widgets::canvas::text_item::TextItem;
 
-const VISIBLE_CHANGED: &str = "visible-changed";
-
 mod imp {
     use std::cell::{Cell, RefCell};
-    use std::sync::OnceLock;
 
-    use gtk::glib::subclass::Signal;
     use gtk::glib::subclass::types::ObjectSubclass;
     use gtk::glib::{self, Properties};
     use gtk::prelude::*;
@@ -50,18 +46,7 @@ mod imp {
     }
 
     #[glib::derived_properties]
-    impl ObjectImpl for SlideImp {
-        fn signals() -> &'static [glib::subclass::Signal] {
-            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
-            SIGNALS.get_or_init(|| {
-                vec![
-                    Signal::builder(super::VISIBLE_CHANGED)
-                        .param_types([bool::static_type()])
-                        .build(),
-                ]
-            })
-        }
-    }
+    impl ObjectImpl for SlideImp {}
 
     impl Default for SlideImp {
         fn default() -> Self {
@@ -78,15 +63,7 @@ mod imp {
         }
     }
 
-    impl SlideImp {
-        pub fn set_visible_(&self, value: bool) {
-            self.visible.set(value);
-            if let Some(c) = self.canvas.borrow().clone() {
-                c.set_visible(value);
-            }
-            self.obj().emit_visible_changed(value);
-        }
-    }
+    impl SlideImp {}
 }
 
 glib::wrapper! {
@@ -100,20 +77,6 @@ impl Default for Slide {
 }
 
 impl Slide {
-    fn emit_visible_changed(&self, value: bool) {
-        self.emit_by_name::<()>(VISIBLE_CHANGED, &[&value]);
-    }
-
-    pub fn connect_visible_changed<F: Fn(bool) + 'static>(&self, f: F) {
-        self.connect_closure(
-            VISIBLE_CHANGED,
-            false,
-            glib::closure_local!(move |_: &Self, value: bool| {
-                f(value);
-            }),
-        );
-    }
-
     pub fn new(/* window: &SpiceWindow, */ save_data: Option<SlideData>) -> Self {
         let slide = glib::Object::new::<Slide>();
 

--- a/src/widgets/search/songs/edit_modal.rs
+++ b/src/widgets/search/songs/edit_modal.rs
@@ -128,6 +128,16 @@ mod imp {
                 if let Some(buf) = slide.entry_buffer() {
                     textview.set_buffer(Some(&buf));
                 }
+
+                slide.connect_visible_notify(glib::clone!(
+                    #[weak]
+                    textview,
+                    move |slide| {
+                        if let Some(w) = textview.parent() {
+                            w.set_visible(slide.visible());
+                        };
+                    }
+                ));
             });
 
             self.list_view.replace(listview.clone());
@@ -487,16 +497,15 @@ impl SongEditWindow {
     pub fn remove_verse(&self) {
         let listview = self.imp().list_view.borrow().clone();
 
-        listview.remove_selected_items();
-        if let Some(model) = listview.model() {
-            if model.n_items() > 0 {
-                model.select_item(model.n_items().saturating_sub(1), true);
-            }
-
-            if let Some(child) = listview.last_child() {
-                child.grab_focus();
-            }
-        }
+        let Some(item) = listview
+            .get_selected_items()
+            .first()
+            .cloned()
+            .and_downcast::<Slide>()
+        else {
+            return;
+        };
+        item.delete();
     }
 
     pub fn ok_reponse(&self) {
@@ -513,7 +522,11 @@ impl SongEditWindow {
 
         let slides = list_items
             .iter()
-            .filter_map(|v| v.downcast_ref::<Slide>().map(|v| v.serialise()))
+            .filter_map(|v| {
+                v.downcast_ref::<Slide>()
+                    .filter(|v| v.visible())
+                    .map(|v| v.serialise())
+            })
             .collect::<Vec<_>>();
         let title = imp.title_entry.borrow_mut().buffer();
 


### PR DESCRIPTION
this commit make removed slide invisible (set visible to false) this implementation is done with a plan to support undo action where delete can be undone by reverting visibility

slides whose canvas is not visible will not be exported