### PR TITLE
feat(ui): add slide preview list SongEditWindow

### DIFF
--- a/src/services/slide.rs
+++ b/src/services/slide.rs
@@ -23,6 +23,8 @@ mod imp {
     pub struct SlideImp {
         pub save_data: RefCell<Option<SlideData>>,
         pub canvas: RefCell<Option<Canvas>>,
+
+        #[property(get)]
         pub preview: RefCell<gtk::Picture>,
 
         #[property(set, get, default_value = "")]
@@ -92,7 +94,13 @@ impl Slide {
         canvas.connect_request_draw_preview(glib::clone!(
             #[weak]
             slide,
-            move || slide.reload_preview_data()
+            move |c| {
+                slide.reload_preview_data();
+
+                slide
+                    .preview()
+                    .set_paintable(c.imp().surface.borrow().clone().as_ref());
+            }
         ));
 
         slide

--- a/src/services/slide.rs
+++ b/src/services/slide.rs
@@ -1,6 +1,12 @@
+use gtk::gdk::prelude::{PaintableExt, TextureExt};
+use gtk::gdk_pixbuf;
+use gtk::gio;
+use gtk::glib::object::Cast;
 use gtk::glib::{self, object::ObjectExt, subclass::types::ObjectSubclassIsExt};
-use gtk::prelude::WidgetExt;
+use gtk::gsk::prelude::GskRendererExt;
+use gtk::prelude::{SnapshotExt, WidgetExt};
 
+use crate::app_config::AppConfig;
 use crate::utils::{self, WidgetChildrenExt};
 use crate::widgets::canvas::canvas::Canvas;
 use crate::widgets::canvas::canvas_item::{CanvasItem, CanvasItemExt};
@@ -27,8 +33,8 @@ mod imp {
         #[property(get)]
         pub preview: RefCell<gtk::Picture>,
 
-        #[property(set, get, default_value = "")]
-        pub preview_data: RefCell<String>,
+        #[property(set, get)]
+        pub preview_data: RefCell<glib::Bytes>,
         #[property(set, get, default_value = "")]
         pub notes: RefCell<String>,
         #[property(set, get, builder(gtk::StackTransitionType::None))]
@@ -56,7 +62,7 @@ mod imp {
                 save_data: RefCell::new(None),
                 canvas: RefCell::new(None),
                 preview: RefCell::new(gtk::Picture::default()),
-                preview_data: RefCell::new(String::default()),
+                preview_data: RefCell::new(glib::Bytes::from(&[])),
                 notes: RefCell::new(String::default()),
                 transition: RefCell::new(gtk::StackTransitionType::None),
                 visible: Cell::new(true),
@@ -79,6 +85,13 @@ impl Default for Slide {
 }
 
 impl Slide {
+    const PREVIEW_WIDTH: i32 = 200;
+    pub fn preview_height() -> i32 {
+        (Self::PREVIEW_WIDTH as f32 / AppConfig::aspect_ratio()) as i32
+    }
+    pub fn preview_width() -> i32 {
+        Self::PREVIEW_WIDTH
+    }
     pub fn new(/* window: &SpiceWindow, */ save_data: Option<SlideData>) -> Self {
         let slide = glib::Object::new::<Slide>();
 
@@ -94,13 +107,7 @@ impl Slide {
         canvas.connect_request_draw_preview(glib::clone!(
             #[weak]
             slide,
-            move |c| {
-                slide.reload_preview_data();
-
-                slide
-                    .preview()
-                    .set_paintable(c.imp().surface.borrow().clone().as_ref());
-            }
+            move |_| slide.reload_preview_data()
         ));
 
         slide
@@ -114,6 +121,8 @@ impl Slide {
             .bidirectional()
             .sync_create()
             .build();
+
+        slide.load_data();
 
         slide
     }
@@ -219,20 +228,11 @@ impl Slide {
             c_item_data.push(ci.serialise());
         }
 
-        //
         let raw_notes = glib::base64_encode(self.notes().as_bytes());
-        // format!(
-        //     "{{{}, \"transition\": {}, \"items\": [{}], \"notes\": \"{}\", \"preview\": \"{}\"}}\n",
-        //     canvas.serialise(),
-        //     i32::from(self.trasition()),
-        //     data,
-        //     raw_notes,
-        //     self.preview_data()
-        // );
         SlideData::new(
             utils::transition_to_int(self.transition()),
             c_item_data,
-            self.preview_data(),
+            self.preview_data().to_vec(),
             canvas.serialise(),
         )
     }
@@ -262,36 +262,39 @@ impl Slide {
     }
 
     pub fn reload_preview_data(&self) {
-        // let s = self.clone();
-        //
-        // glib::timeout_add_local(Duration::from_millis(110), move || {
-        //     let canvas = s.imp().canvas.borrow().clone();
-        //     let canvas_buffer_surface = match canvas {
-        //         Some(c) => c.imp().surface.borrow().clone(),
-        //         None => return glib::ControlFlow::Continue,
-        //     };
-        //     if let Some(surface) = &canvas_buffer_surface
-        //         && let Ok(pix) = surface.load_to_pixbuf()
-        //     {
-        //         let pixbuf = pix.scale_simple(
-        //             SlideList::width(),
-        //             SlideList::height(),
-        //             gdk_pixbuf::InterpType::Bilinear,
-        //         );
-        //
-        //         if let Some(pixbuf) = pixbuf {
-        //             let t = gdk::Texture::for_pixbuf(&pixbuf).upcast::<gdk::Paintable>();
-        //             s.imp().preview.borrow().set_paintable(Some(&t));
-        //             if let Some(p) = utils::pixbuf_to_base64(&pixbuf) {
-        //                 s.set_preview_data(p);
-        //             }
-        //         }
-        //
-        //         return glib::ControlFlow::Break;
-        //     }
-        //
-        //     glib::ControlFlow::Continue
-        // });
+        let s = self.clone();
+        glib::timeout_add_local(std::time::Duration::from_millis(110), move || {
+            let canvas = s.imp().canvas.borrow().clone();
+            let Some(paintable) = canvas.and_then(|c| c.imp().surface.borrow().clone()) else {
+                return glib::ControlFlow::Continue;
+            };
+            s.preview().set_paintable(Some(&paintable));
+
+            let snapshot = gtk::Snapshot::new();
+            let w = Self::preview_width() as f64;
+            let h = Self::preview_height() as f64;
+            paintable.snapshot(&snapshot, w, h);
+
+            let Some(node) = snapshot.to_node() else {
+                return glib::ControlFlow::Continue;
+            };
+
+            let renderer = gtk::gsk::CairoRenderer::new();
+            if renderer.realize(None::<&gtk::gdk::Surface>).is_err() {
+                return glib::ControlFlow::Continue;
+            };
+
+            let texture = renderer.render_texture(
+                &node,
+                Some(&gtk::graphene::Rect::new(0.0, 0.0, w as f32, h as f32)),
+            );
+            renderer.unrealize();
+
+            let data = texture.save_to_png_bytes();
+            s.set_preview_data(data);
+
+            glib::ControlFlow::Break
+        });
     }
 
     fn load_data(&self) {
@@ -299,22 +302,24 @@ impl Slide {
             return;
         };
 
-        self.set_preview_data(save_data.preview);
+        self.set_preview_data(glib::Bytes::from(&save_data.preview));
 
         if !self.preview_data().is_empty() {
-            let pix_buf = utils::base64_to_pixbuf(&self.preview_data().clone());
+            let pix_buf = gdk_pixbuf::Pixbuf::from_stream(
+                &gio::MemoryInputStream::from_bytes(&self.preview_data()),
+                gio::Cancellable::NONE,
+            );
 
-            // TODO:
-            // if let Some(pix_buf) = pix_buf
-            //     && let Some(pix) = pix_buf.scale_simple(
-            //         SlideList::width(),
-            //         SlideList::height(),
-            //         gdk_pixbuf::InterpType::Nearest,
-            //     )
-            // {
-            //     let t = gdk::Texture::for_pixbuf(&pix).upcast::<gdk::Paintable>();
-            //     self.imp().preview.borrow().set_paintable(Some(&t));
-            // }
+            if let Some(pix_buf) = pix_buf.ok()
+                && let Some(pix) = pix_buf.scale_simple(
+                    Self::preview_width(),
+                    Self::preview_height(),
+                    gdk_pixbuf::InterpType::Bilinear,
+                )
+            {
+                let t = gtk::gdk::Texture::for_pixbuf(&pix).upcast::<gtk::gdk::Paintable>();
+                self.imp().preview.borrow().set_paintable(Some(&t));
+            }
         }
 
         self.set_transition(utils::int_to_transition(save_data.transition));

--- a/src/services/slide.rs
+++ b/src/services/slide.rs
@@ -27,6 +27,8 @@ mod imp {
     pub struct SlideImp {
         pub save_data: RefCell<Option<SlideData>>,
         pub canvas: RefCell<Option<Canvas>>,
+
+        #[property(get)]
         pub preview: RefCell<gtk::Picture>,
 
         #[property(set, get, default_value = "")]
@@ -129,7 +131,13 @@ impl Slide {
         canvas.connect_request_draw_preview(glib::clone!(
             #[weak]
             slide,
-            move || slide.reload_preview_data()
+            move |c| {
+                slide.reload_preview_data();
+
+                slide
+                    .preview()
+                    .set_paintable(c.imp().surface.borrow().clone().as_ref());
+            }
         ));
 
         slide

--- a/src/services/slide_manager.rs
+++ b/src/services/slide_manager.rs
@@ -44,7 +44,7 @@ mod imp {
     use gtk::subclass::prelude::*;
 
     use super::*;
-    use crate::services::settings::{self, ApplicationSettings};
+    use crate::services::settings::ApplicationSettings;
     use crate::services::slide::Slide;
     use crate::utils::{WidgetChildrenExt, int_to_transition, transition_to_int};
     use crate::widgets::canvas::canvas_item::CanvasItem;
@@ -144,13 +144,6 @@ mod imp {
             return None;
         }
 
-        // pub fn current_ratio(&self) -> AspectRatio {
-        //     self.current_ratio.borrow().clone()
-        // }
-        // pub fn set_current_ratio(&self, value: AspectRatio) {
-        //     self.current_ratio.replace(value);
-        // }
-
         pub fn propagating_ratio(&self) -> bool {
             self.propagating_ratio.get()
         }
@@ -168,13 +161,13 @@ mod imp {
         #[doc(alias = "set_current_slide")]
         pub fn set_current_slide_(&self, value: Option<Slide>) {
             let obj = self.obj();
-            // if let Some(slide) = self.current_slide.borrow().clone()
-            //     && let Some(canvas) = slide.canvas()
-            // {
-            //     canvas.unselect_all(None);
-            // }
-
             let Some(val) = value else { return };
+
+            if let Some(slide) = self.current_slide.borrow().clone()
+                && let Some(canvas) = slide.canvas()
+            {
+                canvas.unselect_all(None);
+            }
 
             if obj.animation() {
                 let mut t = transition_to_int(val.transition());
@@ -197,7 +190,9 @@ mod imp {
             } else if val == self.end_presentation_slide.borrow().clone() {
                 val.set_visible(true);
                 val.set_presentation_mode(true);
-            }
+            } else {
+                return;
+            };
 
             val.load_slide();
             self.current_slide.replace(Some(val.clone()));

--- a/src/widgets/canvas/canvas.rs
+++ b/src/widgets/canvas/canvas.rs
@@ -295,7 +295,6 @@ mod imp {
             let size = gtk::graphene::Size::new(w as f32, h as f32);
             let paint = s.to_paintable(Some(&size));
             self.surface.replace(paint);
-            obj.emit_request_draw_preview();
         }
     }
 }

--- a/src/widgets/canvas/canvas.rs
+++ b/src/widgets/canvas/canvas.rs
@@ -16,7 +16,7 @@ mod imp {
     use gtk::glib::subclass::types::ObjectSubclass;
     use gtk::prelude::*;
     use gtk::subclass::prelude::*;
-    use gtk::{GestureClick, glib};
+    use gtk::{GestureClick, gdk, glib};
 
     use core::f64;
     use std::cell::{Cell, RefCell};
@@ -58,7 +58,7 @@ mod imp {
 
         pub widget: RefCell<gtk::Overlay>,
         // pub canvas_items: RefCell<Vec<CanvasItem>>,
-        pub surface: RefCell<Option<gtk::cairo::ImageSurface>>,
+        pub surface: RefCell<Option<gdk::Paintable>>,
 
         #[property(get, set, construct)]
         pub presentation_mode: Cell<bool>,
@@ -77,15 +77,9 @@ mod imp {
     impl WidgetImpl for ImpCanvas {
         fn snapshot(&self, snapshot: &gtk::Snapshot) {
             self.parent_snapshot(snapshot);
-
-            // Canvas::set_drawing_preview(true);
-
-            // self._snapshot_widget();
-
-            // Canvas::set_drawing_preview(false);
+            self._snapshot_widget();
         }
     }
-    impl BoxImpl for ImpCanvas {}
 
     pub const REQUEST_DRAW_PREVIEW: &str = "request-draw-preview";
     pub const ITEM_CLICKED: &str = "item-clicked";
@@ -101,7 +95,6 @@ mod imp {
             let obj = self.obj().clone();
 
             obj.connect_presentation_mode_notify(|c| {
-                // println!("-NOTIFY C_PRESENTATION_MODE {}", c.presentation_mode());
                 if c.presentation_mode() {
                     c.unselect_all(None);
                 }
@@ -211,6 +204,7 @@ mod imp {
             self.grid.replace(None);
         }
     }
+    impl BoxImpl for ImpCanvas {}
 
     impl ImpCanvas {
         fn set_current_ratio_(&self, value: f64) {
@@ -279,7 +273,8 @@ mod imp {
         }
 
         fn _snapshot_widget(&self) {
-            if !self.obj().is_realized() {
+            let obj = self.obj().clone();
+            if !obj.is_realized() {
                 return;
             }
 
@@ -288,7 +283,7 @@ mod imp {
             self.obj().snapshot_child(&self.widget.borrow().clone(), &s);
             super::Canvas::set_drawing_preview(false);
 
-            let Some((_, _, _w, _h)) = self.obj().bounds() else {
+            let Some((_, _, w, h)) = self.obj().bounds() else {
                 glib::g_log!(
                     "Canvas Snapshot",
                     glib::LogLevel::Warning,
@@ -297,33 +292,10 @@ mod imp {
                 return;
             };
 
-            let Some(_node) = s.clone().to_node() else {
-                glib::g_log!(
-                    "Canvas Snapshot",
-                    glib::LogLevel::Warning,
-                    "Could not get node",
-                );
-                return;
-            };
-
-            // let Ok(buffer_surface) = BufferSurface::new(w, h) else {
-            //     glib::g_log!(
-            //         "Canvas Snapshot",
-            //         glib::LogLevel::Warning,
-            //         "Could not create buffer-surface"
-            //     );
-            //     return;
-            // };
-            //
-            // if let Some(surface) = buffer_surface.surface() {
-            //     let Ok(ctx) = gtk::cairo::Context::new(&surface) else {
-            //         return;
-            //     };
-            //     node.draw(&ctx);
-            // }
-
-            // self.surface.replace(Some(buffer_surface));
-            self.surface.replace(None);
+            let size = gtk::graphene::Size::new(w as f32, h as f32);
+            let paint = s.to_paintable(Some(&size));
+            self.surface.replace(paint);
+            obj.emit_request_draw_preview();
         }
     }
 }
@@ -568,12 +540,15 @@ impl Canvas {
             glib::closure_local!(move |_: &Self, g: &GestureClick| f(g)),
         )
     }
-    pub fn connect_request_draw_preview<F: Fn() + 'static>(&self, f: F) -> glib::SignalHandlerId {
+    pub fn connect_request_draw_preview<F: Fn(&Self) + 'static>(
+        &self,
+        f: F,
+    ) -> glib::SignalHandlerId {
         self.connect_closure(
             imp::REQUEST_DRAW_PREVIEW,
             false,
-            glib::closure_local!(move |_: &Self| {
-                f();
+            glib::closure_local!(move |c: &Self| {
+                f(c);
             }),
         )
     }

--- a/src/widgets/canvas/serialise.rs
+++ b/src/widgets/canvas/serialise.rs
@@ -77,7 +77,7 @@ pub enum CanvasItemType {
 pub struct SlideData {
     pub transition: u32,
     pub items: Vec<CanvasItemData>,
-    pub preview: String,
+    pub preview: Vec<u8>,
     #[serde(flatten)]
     pub canvas_data: CanvasData,
 }
@@ -86,7 +86,7 @@ impl SlideData {
     pub fn new<I: IntoIterator<Item = CanvasItemData>>(
         transition: u32,
         items: I,
-        preview: String,
+        preview: Vec<u8>,
         canvas_data: CanvasData,
     ) -> Self {
         Self {

--- a/src/widgets/search/songs/edit_modal.rs
+++ b/src/widgets/search/songs/edit_modal.rs
@@ -51,6 +51,8 @@ mod imp {
 
         // EditSongModalListItem
         pub list_view: RefCell<gtk::ListView>,
+        pub preview_list: RefCell<gtk::ListView>,
+        pub(super) notebook: RefCell<gtk::Notebook>,
     }
 
     #[glib::object_subclass]
@@ -76,6 +78,8 @@ mod imp {
             let model = gtk::gio::ListStore::new::<Slide>();
             let selection_model = gtk::SingleSelection::new(Some(model));
             let factory = gtk::SignalListItemFactory::new();
+            let list_stack = gtk::Notebook::builder().vexpand(true).build();
+            self.notebook.replace(list_stack.clone());
 
             let listview = gtk::ListView::builder()
                 .vexpand(true)
@@ -83,6 +87,21 @@ mod imp {
                 .model(&selection_model)
                 .show_separators(true)
                 .build();
+            {
+                let slide_scrolled = gtk::ScrolledWindow::builder()
+                    .vexpand(true)
+                    .child(&listview)
+                    .build();
+                list_stack.append_page(&slide_scrolled, Some(&gtk::Label::new(Some("Text"))));
+            }
+            let preview_list = self.build_preview_list(&selection_model);
+            {
+                let slide_scrolled = gtk::ScrolledWindow::builder()
+                    .vexpand(true)
+                    .child(&preview_list)
+                    .build();
+                list_stack.append_page(&slide_scrolled, Some(&gtk::Label::new(Some("Preview"))));
+            }
 
             factory.connect_setup({
                 let listview = listview.clone();
@@ -131,6 +150,7 @@ mod imp {
             });
 
             self.list_view.replace(listview.clone());
+            self.preview_list.replace(preview_list.clone());
 
             let box_ui = gtk::Box::builder()
                 .orientation(gtk::Orientation::Vertical)
@@ -203,10 +223,7 @@ mod imp {
                     .build();
                 editor_frame.append(&frame_box);
 
-                let slide_scrolled = gtk::ScrolledWindow::builder().vexpand(true).build();
-                frame_box.append(&slide_scrolled);
-
-                slide_scrolled.set_child(Some(&listview));
+                frame_box.append(&list_stack);
 
                 let slide_footer_toolbox = gtk::Box::builder()
                     .orientation(gtk::Orientation::Horizontal)
@@ -318,6 +335,8 @@ mod imp {
             };
             box_ui.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
             box_ui.append(&footer_box);
+
+            obj.register_list_view_selection_changed();
         }
 
         fn signals() -> &'static [glib::subclass::Signal] {
@@ -336,6 +355,57 @@ mod imp {
     impl WindowImpl for SongEditWindow {}
 
     impl SongEditWindow {
+        fn build_preview_list(&self, model: &impl IsA<gtk::SelectionModel>) -> gtk::ListView {
+            let factory = gtk::SignalListItemFactory::new();
+
+            let listview = gtk::ListView::builder()
+                .vexpand(true)
+                .factory(&factory)
+                .model(model)
+                .show_separators(true)
+                .build();
+
+            factory.connect_setup({
+                move |_, list_item| {
+                    let li = list_item
+                        .downcast_ref::<gtk::ListItem>()
+                        .expect("Needs to be ListItem");
+
+                    let b = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+                    b.set_halign(gtk::Align::Center);
+                    b.set_valign(gtk::Align::Center);
+                    li.set_child(Some(&b));
+                }
+            });
+
+            factory.connect_bind(move |_, list_item| {
+                let slide = list_item
+                    .downcast_ref::<gtk::ListItem>()
+                    .expect("Needs to be ListItem")
+                    .item()
+                    .and_downcast::<Slide>()
+                    .expect("The item has to be an `Slide`.");
+
+                let container = list_item
+                    .downcast_ref::<gtk::ListItem>()
+                    .expect("Needs to be ListItem")
+                    .child()
+                    .and_downcast::<gtk::Box>()
+                    .expect("The child has to be a `Box`.");
+
+                let pic = slide.preview();
+                pic.set_can_shrink(true);
+                pic.set_content_fit(gtk::ContentFit::Contain);
+                pic.set_height_request(120);
+                pic.set_hexpand(true);
+                pic.set_halign(gtk::Align::Center);
+                pic.set_valign(gtk::Align::Center);
+                container.append(&pic);
+            });
+
+            listview
+        }
+
         fn setup_key_controller(&self, tv: &gtk::TextView, listview: &gtk::ListView) {
             let obj = self.obj();
 
@@ -443,10 +513,7 @@ impl Default for SongEditWindow {
 
 impl SongEditWindow {
     pub fn new() -> Self {
-        let obj: Self = glib::Object::new();
-        obj.register_list_view_selection_changed();
-
-        obj
+        glib::Object::new()
     }
 
     pub fn show(&self, song: Option<SlideManagerData>) {
@@ -468,34 +535,57 @@ impl SongEditWindow {
     }
 
     pub fn add_new_verse(&self) {
-        let listview = self.imp().list_view.borrow().clone();
+        let Some(page) = self.current_page() else {
+            return;
+        };
+
         let sm = self.imp().slide_manager.borrow();
         let slide = sm.new_slide(Some(SlideData::from_default()), true);
-        listview.append_item(&slide);
+        page.append_item(&slide);
 
-        if let Some(model) = listview.model() {
+        if let Some(model) = page.model() {
             if model.n_items() > 0 {
                 model.select_item(model.n_items().saturating_sub(1), true);
             }
 
-            if let Some(child) = listview.last_child() {
+            if let Some(child) = page.last_child() {
                 child.grab_focus();
             }
         }
     }
 
     pub fn remove_verse(&self) {
-        let listview = self.imp().list_view.borrow().clone();
+        let Some(page) = self.current_page() else {
+            return;
+        };
 
-        listview.remove_selected_items();
-        if let Some(model) = listview.model() {
-            if model.n_items() > 0 {
-                model.select_item(model.n_items().saturating_sub(1), true);
-            }
+        let Some(model) = page.model().and_downcast::<gtk::SingleSelection>() else {
+            return;
+        };
+        let selection = model.selected();
+        page.remove_selected_items();
 
-            if let Some(child) = listview.last_child() {
-                child.grab_focus();
-            }
+        let total = model.n_items();
+        if total == 0 {
+            self.add_new_verse();
+            return;
+        };
+
+        let next = selection.min(total - 1);
+
+        model.select_item(next, true);
+        page.scroll_to(next, gtk::ListScrollFlags::FOCUS, None);
+        self.handle_selection_change();
+    }
+
+    fn current_page(&self) -> Option<gtk::ListView> {
+        let notebook = self.imp().notebook.borrow().clone();
+        let imp = self.imp();
+        match notebook.current_page() {
+            Some(0) => Some(imp.list_view.borrow().clone()),
+            Some(1) => Some(imp.preview_list.borrow().clone()),
+            Some(_) => None,
+            None => None,
         }
     }
 
@@ -561,20 +651,20 @@ impl SongEditWindow {
         list_model.connect_selection_changed(glib::clone!(
             #[weak(rename_to=obj)]
             self,
-            #[strong]
-            list_view,
-            move |_, _, _| {
-                let list = list_view.clone();
-                let item = list.get_selected_items().first().cloned();
-
-                let slide = item.and_downcast::<Slide>();
-                obj.imp().slide_manager.borrow().set_current_slide(slide);
-            }
+            move |_, _, _| obj.handle_selection_change()
         ));
 
         if list_model.n_items() > 0 {
-            list_model.select_item(1, true);
+            list_model.select_item(0, true);
         }
+    }
+
+    fn handle_selection_change(&self) {
+        let list = self.imp().list_view.borrow().clone();
+        let item = list.get_selected_items().first().cloned();
+
+        let slide = item.and_downcast::<Slide>();
+        self.imp().slide_manager.borrow().set_current_slide(slide);
     }
 
     fn emit_save(&self, song: &SlideManagerData) {

--- a/src/widgets/search/songs/edit_modal.rs
+++ b/src/widgets/search/songs/edit_modal.rs
@@ -51,6 +51,8 @@ mod imp {
 
         // EditSongModalListItem
         pub list_view: RefCell<gtk::ListView>,
+        pub preview_list: RefCell<gtk::ListView>,
+        pub(super) notebook: RefCell<gtk::Notebook>,
     }
 
     #[glib::object_subclass]
@@ -76,6 +78,8 @@ mod imp {
             let model = gtk::gio::ListStore::new::<Slide>();
             let selection_model = gtk::SingleSelection::new(Some(model));
             let factory = gtk::SignalListItemFactory::new();
+            let list_stack = gtk::Notebook::builder().vexpand(true).build();
+            self.notebook.replace(list_stack.clone());
 
             let listview = gtk::ListView::builder()
                 .vexpand(true)
@@ -83,6 +87,21 @@ mod imp {
                 .model(&selection_model)
                 .show_separators(true)
                 .build();
+            {
+                let slide_scrolled = gtk::ScrolledWindow::builder()
+                    .vexpand(true)
+                    .child(&listview)
+                    .build();
+                list_stack.append_page(&slide_scrolled, Some(&gtk::Label::new(Some("Text"))));
+            }
+            let preview_list = self.build_preview_list(&selection_model);
+            {
+                let slide_scrolled = gtk::ScrolledWindow::builder()
+                    .vexpand(true)
+                    .child(&preview_list)
+                    .build();
+                list_stack.append_page(&slide_scrolled, Some(&gtk::Label::new(Some("Preview"))));
+            }
 
             factory.connect_setup({
                 let listview = listview.clone();
@@ -133,14 +152,13 @@ mod imp {
                     #[weak]
                     textview,
                     move |slide| {
-                        if let Some(w) = textview.parent() {
-                            w.set_visible(slide.visible());
-                        };
+                        textview.parent().map(|w| w.set_visible(slide.visible()));
                     }
                 ));
             });
 
             self.list_view.replace(listview.clone());
+            self.preview_list.replace(preview_list.clone());
 
             let box_ui = gtk::Box::builder()
                 .orientation(gtk::Orientation::Vertical)
@@ -213,10 +231,7 @@ mod imp {
                     .build();
                 editor_frame.append(&frame_box);
 
-                let slide_scrolled = gtk::ScrolledWindow::builder().vexpand(true).build();
-                frame_box.append(&slide_scrolled);
-
-                slide_scrolled.set_child(Some(&listview));
+                frame_box.append(&list_stack);
 
                 let slide_footer_toolbox = gtk::Box::builder()
                     .orientation(gtk::Orientation::Horizontal)
@@ -328,6 +343,8 @@ mod imp {
             };
             box_ui.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
             box_ui.append(&footer_box);
+
+            obj.register_list_view_selection_changed();
         }
 
         fn signals() -> &'static [glib::subclass::Signal] {
@@ -346,6 +363,65 @@ mod imp {
     impl WindowImpl for SongEditWindow {}
 
     impl SongEditWindow {
+        fn build_preview_list(&self, model: &impl IsA<gtk::SelectionModel>) -> gtk::ListView {
+            let factory = gtk::SignalListItemFactory::new();
+
+            let listview = gtk::ListView::builder()
+                .vexpand(true)
+                .factory(&factory)
+                .model(model)
+                .show_separators(true)
+                .build();
+
+            factory.connect_setup({
+                move |_, list_item| {
+                    let li = list_item
+                        .downcast_ref::<gtk::ListItem>()
+                        .expect("Needs to be ListItem");
+
+                    let b = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+                    b.set_halign(gtk::Align::Center);
+                    b.set_valign(gtk::Align::Center);
+                    li.set_child(Some(&b));
+                }
+            });
+
+            factory.connect_bind(move |_, list_item| {
+                let slide = list_item
+                    .downcast_ref::<gtk::ListItem>()
+                    .expect("Needs to be ListItem")
+                    .item()
+                    .and_downcast::<Slide>()
+                    .expect("The item has to be an `Slide`.");
+
+                let container = list_item
+                    .downcast_ref::<gtk::ListItem>()
+                    .expect("Needs to be ListItem")
+                    .child()
+                    .and_downcast::<gtk::Box>()
+                    .expect("The child has to be a `Box`.");
+
+                let pic = slide.preview();
+                pic.set_can_shrink(true);
+                pic.set_content_fit(gtk::ContentFit::Contain);
+                pic.set_height_request(120);
+                pic.set_hexpand(true);
+                pic.set_halign(gtk::Align::Center);
+                pic.set_valign(gtk::Align::Center);
+                container.append(&pic);
+
+                slide.connect_visible_notify(glib::clone!(
+                    #[weak]
+                    container,
+                    move |slide| {
+                        container.parent().map(|w| w.set_visible(slide.visible()));
+                    }
+                ));
+            });
+
+            listview
+        }
+
         fn setup_key_controller(&self, tv: &gtk::TextView, listview: &gtk::ListView) {
             let obj = self.obj();
 
@@ -453,10 +529,7 @@ impl Default for SongEditWindow {
 
 impl SongEditWindow {
     pub fn new() -> Self {
-        let obj: Self = glib::Object::new();
-        obj.register_list_view_selection_changed();
-
-        obj
+        glib::Object::new()
     }
 
     pub fn show(&self, song: Option<SlideManagerData>) {
@@ -478,26 +551,31 @@ impl SongEditWindow {
     }
 
     pub fn add_new_verse(&self) {
-        let listview = self.imp().list_view.borrow().clone();
+        let Some(page) = self.current_page() else {
+            return;
+        };
+
         let sm = self.imp().slide_manager.borrow();
         let slide = sm.new_slide(Some(SlideData::from_default()), true);
-        listview.append_item(&slide);
+        page.append_item(&slide);
 
-        if let Some(model) = listview.model() {
+        if let Some(model) = page.model() {
             if model.n_items() > 0 {
                 model.select_item(model.n_items().saturating_sub(1), true);
             }
 
-            if let Some(child) = listview.last_child() {
+            if let Some(child) = page.last_child() {
                 child.grab_focus();
             }
         }
     }
 
     pub fn remove_verse(&self) {
-        let listview = self.imp().list_view.borrow().clone();
+        let Some(page) = self.current_page() else {
+            return;
+        };
 
-        let Some(item) = listview
+        let Some(item) = page
             .get_selected_items()
             .first()
             .cloned()
@@ -505,7 +583,34 @@ impl SongEditWindow {
         else {
             return;
         };
+        let Some(model) = page.model().and_downcast::<gtk::SingleSelection>() else {
+            return;
+        };
+        let selection = model.selected();
         item.delete();
+
+        let total = model.n_items();
+        if total == 0 {
+            self.add_new_verse();
+            return;
+        };
+
+        let next = selection.min(total - 1);
+
+        model.select_item(next, true);
+        page.scroll_to(next, gtk::ListScrollFlags::FOCUS, None);
+        self.handle_selection_change();
+    }
+
+    fn current_page(&self) -> Option<gtk::ListView> {
+        let notebook = self.imp().notebook.borrow().clone();
+        let imp = self.imp();
+        match notebook.current_page() {
+            Some(0) => Some(imp.list_view.borrow().clone()),
+            Some(1) => Some(imp.preview_list.borrow().clone()),
+            Some(_) => None,
+            None => None,
+        }
     }
 
     pub fn ok_reponse(&self) {
@@ -574,20 +679,20 @@ impl SongEditWindow {
         list_model.connect_selection_changed(glib::clone!(
             #[weak(rename_to=obj)]
             self,
-            #[strong]
-            list_view,
-            move |_, _, _| {
-                let list = list_view.clone();
-                let item = list.get_selected_items().first().cloned();
-
-                let slide = item.and_downcast::<Slide>();
-                obj.imp().slide_manager.borrow().set_current_slide(slide);
-            }
+            move |_, _, _| obj.handle_selection_change()
         ));
 
         if list_model.n_items() > 0 {
-            list_model.select_item(1, true);
+            list_model.select_item(0, true);
         }
+    }
+
+    fn handle_selection_change(&self) {
+        let list = self.imp().list_view.borrow().clone();
+        let item = list.get_selected_items().first().cloned();
+
+        let slide = item.and_downcast::<Slide>();
+        self.imp().slide_manager.borrow().set_current_slide(slide);
     }
 
     fn emit_save(&self, song: &SlideManagerData) {

--- a/src/widgets/search/songs/edit_modal.rs
+++ b/src/widgets/search/songs/edit_modal.rs
@@ -373,19 +373,6 @@ mod imp {
                 .show_separators(true)
                 .build();
 
-            factory.connect_setup({
-                move |_, list_item| {
-                    let li = list_item
-                        .downcast_ref::<gtk::ListItem>()
-                        .expect("Needs to be ListItem");
-
-                    let b = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-                    b.set_halign(gtk::Align::Center);
-                    b.set_valign(gtk::Align::Center);
-                    li.set_child(Some(&b));
-                }
-            });
-
             factory.connect_bind(move |_, list_item| {
                 let slide = list_item
                     .downcast_ref::<gtk::ListItem>()
@@ -396,27 +383,18 @@ mod imp {
 
                 let container = list_item
                     .downcast_ref::<gtk::ListItem>()
-                    .expect("Needs to be ListItem")
-                    .child()
-                    .and_downcast::<gtk::Box>()
-                    .expect("The child has to be a `Box`.");
+                    .expect("Needs to be ListItem");
 
                 let pic = slide.preview();
                 pic.set_can_shrink(true);
                 pic.set_content_fit(gtk::ContentFit::Contain);
-                pic.set_height_request(120);
-                pic.set_hexpand(true);
-                pic.set_halign(gtk::Align::Center);
-                pic.set_valign(gtk::Align::Center);
-                container.append(&pic);
+                pic.set_height_request(Slide::preview_height());
+                pic.set_width_request(Slide::preview_width());
+                container.set_child(Some(&pic));
 
-                slide.connect_visible_notify(glib::clone!(
-                    #[weak]
-                    container,
-                    move |slide| {
-                        container.parent().map(|w| w.set_visible(slide.visible()));
-                    }
-                ));
+                slide.connect_visible_notify(move |slide| {
+                    pic.parent().map(|w| w.set_visible(slide.visible()));
+                });
             });
 
             listview
@@ -564,9 +542,13 @@ impl SongEditWindow {
                 model.select_item(model.n_items().saturating_sub(1), true);
             }
 
-            if let Some(child) = page.last_child() {
-                child.grab_focus();
-            }
+            glib::timeout_add_local_once(std::time::Duration::from_millis(100), move || {
+                page.scroll_to(
+                    model.n_items().saturating_sub(1),
+                    gtk::ListScrollFlags::FOCUS,
+                    None,
+                );
+            });
         }
     }
 
@@ -575,31 +557,43 @@ impl SongEditWindow {
             return;
         };
 
-        let Some(item) = page
-            .get_selected_items()
-            .first()
-            .cloned()
-            .and_downcast::<Slide>()
-        else {
-            return;
-        };
+        page.get_selected_items()
+            .iter()
+            .next()
+            .and_then(|item| item.downcast_ref::<Slide>())
+            .map(|c| c.delete());
+
         let Some(model) = page.model().and_downcast::<gtk::SingleSelection>() else {
             return;
         };
-        let selection = model.selected();
-        item.delete();
 
-        let total = model.n_items();
+        let selection = model.selected();
+        let total = page.children().filter(|c| c.is_visible()).count();
         if total == 0 {
             self.add_new_verse();
             return;
         };
 
-        let next = selection.min(total - 1);
+        let listitems = page
+            .children()
+            .enumerate()
+            .filter_map(|(i, c)| c.is_visible().then(|| i))
+            .collect::<Vec<_>>();
+
+        let (lt, gt): (Vec<_>, Vec<_>) = listitems
+            .into_iter()
+            .partition(|x| *x <= selection as usize);
+
+        let next = *gt.first().unwrap_or(lt.last().unwrap_or(&0)) as u32;
+        // println!("[listitems]  {:?} -> {:?}", lt, gt);
 
         model.select_item(next, true);
-        page.scroll_to(next, gtk::ListScrollFlags::FOCUS, None);
         self.handle_selection_change();
+        page.scroll_to(next, gtk::ListScrollFlags::FOCUS, None);
+
+        glib::timeout_add_local_once(std::time::Duration::from_millis(100), move || {
+            page.scroll_to(next, gtk::ListScrollFlags::FOCUS, None);
+        });
     }
 
     fn current_page(&self) -> Option<gtk::ListView> {


### PR DESCRIPTION
Refactor the song editing interface to include a tabbed view (Notebook) allowing users to switch between a text-based list and a visual preview list of slides.

Key changes:
- Canvas: Implement GdkPaintable snapshots to replace Cairo ImageSurfaces. This enables real-time preview generation by emitting a signal when a new snapshot is ready.
- Slide: Add a 'preview' property and connect to the canvas draw signal to update the slide's visual representation.
- SongEditWindow:
    - Introduce a Notebook widget containing both the traditional ListView and a new preview-based ListView.
    - Implement `current_page()` to allow slide operations (add/remove) to work contextually on the active view.
    - Optimize `remove_verse` logic to maintain selection focus and automatically add a new verse if the list becomes empty.
- SlideManager: Restore logic to unselect canvas items when switching slides to prevent ghost selections.

Known Issue:
- [x] Initial preview failing: Loading lyric when window loads fails to render the preview until user interacts with song item