### PR TITLE
Feat bible parser keywords

### DIFF
--- a/src/notepad.rs
+++ b/src/notepad.rs
@@ -179,6 +179,7 @@ fn build_ui(app: &impl IsA<gtk::Application>) -> impl IsA<gtk::Window> {
         let buff_tv = buff_tv.clone();
         move |_, slide| {
             if let Some(canvas) = slide.canvas() {
+                for _ in [0, 0, 0].iter() {}
                 for t in canvas.widget().get_children::<TextItem>() {
                     let buff = t.buffer();
                     buff_tv.set_buffer(Some(&buff));
@@ -189,7 +190,6 @@ fn build_ui(app: &impl IsA<gtk::Application>) -> impl IsA<gtk::Window> {
                         buff,
                         buff_tv.buffer()
                     );
-                    break;
                 }
             }
         }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -500,7 +500,10 @@ fn parse_post_chapter(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpressi
 }
 
 fn parse_verse(p: &mut Parser) -> Option<Vec<NumberLiteral>> {
-    if p.current_token.t_type != TokenEnum::Colon && p.current_token.t_type != TokenEnum::Number {
+    if p.current_token.t_type != TokenEnum::Colon
+        && p.current_token.t_type != TokenEnum::Number
+        && p.current_token.t_type != TokenEnum::Comma
+    {
         return None;
     }
 
@@ -996,7 +999,10 @@ mod test {
         test_program_("1 John 1:1 to 3 5 7 through 10");
         test_program_("open to 1 John 1:1 to 3,5,7-10, lets read");
         test_program_("open 1 John 1:1 to 3,5,7-10, lets read");
-        test_program_("1 John 1, verses 1 to 3,5,7-10, lets read");
+        test_program_("1 John 1, verses 1 to 3,5,7-10");
+        test_program_("1 John chapter 1, verses 1 to 3,5,7-10");
+        test_program_("1 John 1, 1 to 3,5,7-10");
+        test_program_("1 John chapter 1, 1 to 3,5,7-10");
 
         test_program_("1 John 1 1 to 3 5 7 through 10");
         test_program_("1 John 1 1-3 5 7-10");

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -470,11 +470,13 @@ fn parse_post_identifier(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpre
 fn parse_post_chapter(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpression> {
     let number_literal = lhs.get::<NumberLiteral>()?;
 
-    if p.peek_token.t_type != TokenEnum::Colon {
+    if p.peek_token.t_type != TokenEnum::Colon && p.peek_token.t_type != TokenEnum::Number {
         return None;
     }
 
-    p.next_token();
+    if p.peek_token.t_type == TokenEnum::Colon {
+        p.next_token();
+    }
 
     let token = p.current_token.clone();
     let verses = parse_verse(p)?;
@@ -489,11 +491,14 @@ fn parse_post_chapter(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpressi
 }
 
 fn parse_verse(p: &mut Parser) -> Option<Vec<NumberLiteral>> {
-    if p.current_token.t_type != TokenEnum::Colon {
+    println!("{:?}", p.current_token);
+    if p.current_token.t_type != TokenEnum::Colon && p.current_token.t_type != TokenEnum::Number {
         return None;
     }
 
-    p.next_token();
+    if p.current_token.t_type == TokenEnum::Colon {
+        p.next_token();
+    }
 
     let mut verses = Vec::new();
 
@@ -601,7 +606,7 @@ mod test {
             let stmts = parser.parse_program();
 
             let actual = stmts.first().unwrap();
-            _test_identifier(i as u32, expected.get(i).unwrap(), actual);
+            _test_passage_literal(i as u32, expected.get(i).unwrap(), actual);
         }
     }
 
@@ -635,18 +640,18 @@ mod test {
             let stmts = parser.parse_program();
 
             let actual = stmts.first().unwrap();
-            _test_identifier(i as u32, expected.get(i).unwrap(), actual);
+            _test_passage_literal(i as u32, expected.get(i).unwrap(), actual);
         }
     }
 
-    fn _test_identifier(index: u32, expected: &AstExpression, actual: &AstExpression) {
+    fn _test_passage_literal(index: u32, expected: &AstExpression, actual: &AstExpression) {
         let expected_val = expected.get::<PassageLiteral>().unwrap().book.clone();
         let actual_exp = actual.get::<PassageLiteral>();
 
         // ==
         assert!(
             actual_exp.is_some(),
-            "TEST {index}: Expected [AstReference] got [{:?}]",
+            "{index}: Expected [PassageLiteral] got [{:?}]",
             actual_exp
         );
 
@@ -708,6 +713,7 @@ mod test {
         );
     }
 
+    /// data to test is 1-4
     fn range_test_data() -> AstExpression {
         AstExpression::new(AstNode::RangeLiteral(RangeLiteral {
             start: NumberLiteral {
@@ -731,9 +737,8 @@ mod test {
         }))
     }
 
-    #[test]
-    fn test_range_literal_with_through() {
-        let input = String::from("1 through 4");
+    fn test_range_literal_(input: &str) {
+        let input = String::from(input);
         let expected = range_test_data();
 
         let tokenizer = Tokenizer::new(input);
@@ -760,68 +765,21 @@ mod test {
             "expected [{:?}], got [{:?}]",
             tt.token.t_type, ident.token.t_type
         );
+    }
+
+    #[test]
+    fn test_range_literal_with_through() {
+        test_range_literal_("1 through 4");
     }
 
     #[test]
     fn test_range_literal_with_to() {
-        let input = String::from("1 to 4");
-        let expected = range_test_data();
-
-        let tokenizer = Tokenizer::new(input);
-        let mut parser = Parser::new(tokenizer);
-        let stmts = parser.parse_program();
-
-        let expression = stmts.first().unwrap();
-        let ident = expression.get::<RangeLiteral>();
-        let tt = expected.get::<RangeLiteral>().unwrap();
-
-        // ==
-        assert!(ident.is_some(), "Expected RangeLiteral");
-
-        let ident = ident.unwrap();
-
-        assert_eq!(
-            tt.start, ident.start,
-            "expected [{:?}], got [{:?}]",
-            tt.start, ident.start,
-        );
-
-        assert_eq!(
-            ident.token.t_type, tt.token.t_type,
-            "expected [{:?}], got [{:?}]",
-            tt.token.t_type, ident.token.t_type
-        );
+        test_range_literal_("1 to 4");
     }
 
     #[test]
     fn test_range_literal() {
-        let input = String::from("1-4");
-        let expected = range_test_data();
-
-        let tokenizer = Tokenizer::new(input);
-        let mut parser = Parser::new(tokenizer);
-        let stmts = parser.parse_program();
-
-        let expression = stmts.first().unwrap();
-        let ident = expression.get::<RangeLiteral>();
-        let tt = expected.get::<RangeLiteral>().unwrap();
-
-        // ==
-        assert!(ident.is_some(), "Expected RangeLiteral");
-
-        let ident = ident.unwrap();
-
-        assert_eq!(
-            tt.start, ident.start,
-            "expected [{:?}], got [{:?}]",
-            tt.start, ident.start,
-        );
-
-        assert_eq!(
-            ident.token.t_type, tt.token.t_type,
-            "expected [{:?}], got [{:?}]",
-            tt.token.t_type, ident.token.t_type
-        );
+        test_range_literal_("1 - 4");
     }
 
     fn reference_test_data() -> AstExpression {
@@ -911,10 +869,8 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_list_operator() {
-        let input = String::from("1,4,3");
-        let expected_list = [
+    fn list_operator_data() -> [AstExpression; 3] {
+        [
             AstExpression::new(AstNode::NumberLiteral(NumberLiteral {
                 value: 1,
                 token: Token {
@@ -936,7 +892,12 @@ mod test {
                     value: String::from("3"),
                 },
             })),
-        ];
+        ]
+    }
+
+    fn test_list_operator_(input: &str) {
+        let input = String::from(input);
+        let expected_list = list_operator_data();
 
         let tokenizer = Tokenizer::new(input);
         let mut parser = Parser::new(tokenizer);
@@ -969,9 +930,16 @@ mod test {
     }
 
     #[test]
-    fn test_program() {
-        let input = String::from("1 John 1:1 to 3,5,7-10");
-        let expected_list = [AstExpression::new(AstNode::AstReferenceLiteral(
+    fn test_list_operator() {
+        test_list_operator_("1,4,3");
+    }
+    #[test]
+    fn test_list_operator_with_and() {
+        test_list_operator_("1,4 and 3");
+    }
+
+    fn test_program_data() -> [AstExpression; 1] {
+        [AstExpression::new(AstNode::AstReferenceLiteral(
             PassageLiteral {
                 book: Identifier {
                     prefix: Some(NumberLiteral::new(1)),
@@ -998,45 +966,34 @@ mod test {
                     ],
                 },
             },
-        ))];
+        ))]
+    }
 
-        let tokenizer = Tokenizer::new(input);
+    fn test_program_(input: &str) {
+        // let input = String::from("1 John 1:1 to 3,5,7-10");
+        let expected_list = test_program_data();
+
+        let tokenizer = Tokenizer::new(input.into());
         let mut parser = Parser::new(tokenizer);
         let stmts = parser.parse_program();
 
-        {
-            let stmt = stmts.first(); // identifier
-            _test_identifier(0, expected_list.first().unwrap(), stmt.unwrap());
-        }
+        let stmt = stmts.first(); // identifier
+        _test_passage_literal(0, expected_list.first().unwrap(), stmt.unwrap());
+    }
 
-        // {
-        //     let stmt = stmts.get(1); // identifier
-        //     _test_reference_literal(expected_list.get(1).unwrap(), stmt.unwrap());
-        // }
+    #[test]
+    fn test_program_with_space() {
+        test_program_("1 John 1 1 to 3 5 7 through 10");
+        test_program_("1 John 1 1-3 5 7-10");
+        test_program_("1 John 1 1-3 and 5 and 7-10");
+        test_program_("1 John 1 1-3, 5, 7-10");
+    }
 
-        // for (i, expected) in expected_list.iter().enumerate() {
-        //     let stmt = stmts.get(i);
-        //     assert!(stmt.is_some(), "Expected [Some] got [None]");
-        //
-        //     let actual = stmt.unwrap().get::<NumberLiteral>();
-        //     let expected_value = expected.get::<NumberLiteral>().unwrap();
-        //
-        //     // ==
-        //     assert!(actual.is_some(), "Expected [{}]",);
-        //
-        //     let actual = actual.unwrap();
-        //
-        //     assert_eq!(
-        //         expected_value, actual,
-        //         "expected [{:?}], got [{:?}]",
-        //         expected_value, actual,
-        //     );
-        //
-        //     assert_eq!(
-        //         actual.token.t_type, expected_value.token.t_type,
-        //         "expected [{:?}], got [{:?}]",
-        //         expected_value.token.t_type, actual.token.t_type
-        //     );
-        // }
+    #[test]
+    fn test_program() {
+        test_program_("1 John 1:1 to 3,5,7-10");
+        test_program_("1 John 1:1 to 3,5 and 7-10");
+        test_program_("1 John 1:1 to 3 5 7 through 10");
+        test_program_("1 John 1 1 to 3 5 7 through 10");
     }
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -80,7 +80,7 @@ impl NumberLiteral {
             value,
             token: Token {
                 value: value.to_string(),
-                t_type: TokenEnum::NUMBER,
+                t_type: TokenEnum::Number,
             },
         }
     }
@@ -148,45 +148,45 @@ impl Expression for Identifier {
 }
 
 impl FromAstNode for Identifier {
-    fn from_node(node: &AstNode) -> Option<&Self> {
+    fn try_from_node(node: &AstNode) -> Option<&Self> {
         match node {
             AstNode::Identifier(val) => Some(val),
-            _ => return None,
+            _ => None,
         }
     }
 }
 
 impl FromAstNode for NumberLiteral {
-    fn from_node(node: &AstNode) -> Option<&Self> {
+    fn try_from_node(node: &AstNode) -> Option<&Self> {
         match node {
             AstNode::NumberLiteral(val) => Some(val),
-            _ => return None,
+            _ => None,
         }
     }
 }
 
 impl FromAstNode for RangeLiteral {
-    fn from_node(node: &AstNode) -> Option<&Self> {
+    fn try_from_node(node: &AstNode) -> Option<&Self> {
         match node {
             AstNode::RangeLiteral(val) => Some(val),
-            _ => return None,
+            _ => None,
         }
     }
 }
 impl FromAstNode for ReferenceLiteral {
-    fn from_node(node: &AstNode) -> Option<&Self> {
+    fn try_from_node(node: &AstNode) -> Option<&Self> {
         match node {
             AstNode::ReferenceLiteral(val) => Some(val),
-            _ => return None,
+            _ => None,
         }
     }
 }
 
 impl FromAstNode for PassageLiteral {
-    fn from_node(node: &AstNode) -> Option<&Self> {
+    fn try_from_node(node: &AstNode) -> Option<&Self> {
         match node {
             AstNode::AstReferenceLiteral(val) => Some(val),
-            _ => return None,
+            _ => None,
         }
     }
 }
@@ -201,12 +201,12 @@ enum AstNode {
 }
 
 trait FromAstNode {
-    fn from_node(node: &AstNode) -> Option<&Self>;
+    fn try_from_node(node: &AstNode) -> Option<&Self>;
 }
 
 impl AstNode {
-    fn from_node<T: FromAstNode>(&self) -> Option<&T> {
-        T::from_node(self)
+    fn try_from_node<T: FromAstNode>(&self) -> Option<&T> {
+        T::try_from_node(self)
     }
 }
 
@@ -221,7 +221,7 @@ impl AstExpression {
     }
 
     fn get<T: FromAstNode>(&self) -> Option<&T> {
-        self.node.from_node::<T>()
+        self.node.try_from_node::<T>()
     }
 }
 
@@ -267,7 +267,7 @@ impl Parser {
             current_token,
             peek_token: next_token,
             prev_token: Token {
-                t_type: TokenEnum::EOF,
+                t_type: TokenEnum::Eof,
                 value: String::from('\0'),
             },
 
@@ -279,17 +279,17 @@ impl Parser {
         };
 
         // prefix
-        parser.register_prefix(TokenEnum::IDENTIFIER, parse_prefix_identifier);
-        parser.register_prefix(TokenEnum::NUMBER, parse_number);
+        parser.register_prefix(TokenEnum::Identifier, parse_prefix_identifier);
+        parser.register_prefix(TokenEnum::Number, parse_number);
         // parser.register_prefix(TokenEnum::COLON, parse_pre_verse);
 
         // infix
-        parser.register_infix(TokenEnum::HYPHEN, parse_range);
+        parser.register_infix(TokenEnum::Hyphen, parse_range);
         // parser.register_infix(TokenEnum::COLON, parse_page);
 
         // postfix
-        parser.register_postfix(TokenEnum::IDENTIFIER, parse_post_identifier);
-        parser.register_postfix(TokenEnum::COLON, parse_post_chapter);
+        parser.register_postfix(TokenEnum::Identifier, parse_post_identifier);
+        parser.register_postfix(TokenEnum::Colon, parse_post_chapter);
 
         parser
     }
@@ -325,13 +325,12 @@ impl Parser {
     fn parse_program(&mut self) -> Vec<AstExpression> {
         let mut stmts = Vec::new();
 
-        while self.current_token.t_type.ne(&TokenEnum::EOF) {
+        while self.current_token.t_type.ne(&TokenEnum::Eof) {
             // parse statement
             let stmt = self.parse_expression_statement();
 
             if let Some(stmt) = stmt {
                 stmts.push(stmt)
-            } else {
             };
 
             self.next_token();
@@ -342,7 +341,7 @@ impl Parser {
 
     fn parse_expression_statement(&mut self) -> Option<AstExpression> {
         let expression = self.parse_expression();
-        if self.peek_token.t_type == TokenEnum::EOF {
+        if self.peek_token.t_type == TokenEnum::Eof {
             self.next_token();
         }
 
@@ -360,11 +359,11 @@ impl Parser {
 
         let mut left_exp = prefix_fn(self)?;
 
-        while self.current_token.t_type.ne(&TokenEnum::COMMA)
-            && self.current_token.t_type.ne(&TokenEnum::SEMICOLON)
+        while self.current_token.t_type.ne(&TokenEnum::Comma)
+            && self.current_token.t_type.ne(&TokenEnum::Semicolon)
         {
             // check for infix
-            let t_type = self.peek_token.t_type.clone();
+            let t_type = self.peek_token.t_type;
             if !self.infix_fn.contains_key(&t_type) {
                 break;
             }
@@ -381,7 +380,7 @@ impl Parser {
         }
 
         //get postfix
-        let peek_ttype = self.peek_token.t_type.clone();
+        let peek_ttype = self.peek_token.t_type;
         if let Some(post_fn) = self.postfix_fn.get(&peek_ttype)
             && let Some(post) = post_fn(self, &left_exp)
         {
@@ -394,7 +393,7 @@ impl Parser {
                 let chapter = parse_number(self)?;
                 let chapter_ref = parse_post_chapter(self, &chapter)?
                     .node
-                    .from_node::<ReferenceLiteral>()?
+                    .try_from_node::<ReferenceLiteral>()?
                     .clone();
                 let book_ref = PassageLiteral {
                     book: ident,
@@ -410,7 +409,7 @@ impl Parser {
 }
 
 fn parse_number(p: &mut Parser) -> Option<AstExpression> {
-    if p.current_token.t_type != TokenEnum::NUMBER {
+    if p.current_token.t_type != TokenEnum::Number {
         return None;
     }
 
@@ -431,7 +430,7 @@ fn parse_number(p: &mut Parser) -> Option<AstExpression> {
 }
 
 fn parse_range(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpression> {
-    if p.current_token.t_type != TokenEnum::HYPHEN {
+    if p.current_token.t_type != TokenEnum::Hyphen {
         return None;
     }
 
@@ -471,7 +470,7 @@ fn parse_post_identifier(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpre
 fn parse_post_chapter(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpression> {
     let number_literal = lhs.get::<NumberLiteral>()?;
 
-    if p.peek_token.t_type != TokenEnum::COLON {
+    if p.peek_token.t_type != TokenEnum::Colon {
         return None;
     }
 
@@ -490,7 +489,7 @@ fn parse_post_chapter(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpressi
 }
 
 fn parse_verse(p: &mut Parser) -> Option<Vec<NumberLiteral>> {
-    if p.current_token.t_type != TokenEnum::COLON {
+    if p.current_token.t_type != TokenEnum::Colon {
         return None;
     }
 
@@ -506,10 +505,10 @@ fn parse_verse(p: &mut Parser) -> Option<Vec<NumberLiteral>> {
         hold = Some(num.clone());
     };
 
-    while p.current_token.t_type.ne(&TokenEnum::EOF)
-        && p.current_token.t_type.ne(&TokenEnum::SEMICOLON)
+    while p.current_token.t_type.ne(&TokenEnum::Eof)
+        && p.current_token.t_type.ne(&TokenEnum::Semicolon)
     {
-        if p.peek_token.t_type == TokenEnum::IDENTIFIER {
+        if p.peek_token.t_type == TokenEnum::Identifier {
             break;
         }
         let verse = p.parse_expression();
@@ -544,11 +543,11 @@ fn parse_verse(p: &mut Parser) -> Option<Vec<NumberLiteral>> {
 }
 
 fn parse_prefix_identifier(p: &mut Parser) -> Option<AstExpression> {
-    if p.current_token.t_type != TokenEnum::IDENTIFIER {
+    if p.current_token.t_type != TokenEnum::Identifier {
         return None;
     }
 
-    if p.peek_token.t_type != TokenEnum::NUMBER {
+    if p.peek_token.t_type != TokenEnum::Number && p.peek_token.t_type != TokenEnum::Chapter {
         return None;
     }
 
@@ -558,7 +557,13 @@ fn parse_prefix_identifier(p: &mut Parser) -> Option<AstExpression> {
         prefix: None,
     };
 
-    Some(AstExpression::new(AstNode::Identifier(ident)))
+    let identifier = AstExpression::new(AstNode::Identifier(ident));
+
+    if p.peek_token.t_type == TokenEnum::Chapter {
+        p.next_token();
+    }
+
+    Some(identifier)
 }
 
 #[cfg(test)]
@@ -575,14 +580,14 @@ mod test {
                     prefix: None,
                     value: String::from("John"),
                     token: Token {
-                        t_type: TokenEnum::IDENTIFIER,
+                        t_type: TokenEnum::Identifier,
                         value: String::from("John"),
                     },
                 },
                 reference: ReferenceLiteral {
                     chapter: NumberLiteral::new(1),
                     token: Token {
-                        t_type: TokenEnum::COLON,
+                        t_type: TokenEnum::Colon,
                         value: String::from(":"),
                     },
                     verses: vec![NumberLiteral::new(1)],
@@ -609,14 +614,14 @@ mod test {
                     prefix: Some(NumberLiteral::new(3)),
                     value: String::from("John"),
                     token: Token {
-                        t_type: TokenEnum::IDENTIFIER,
+                        t_type: TokenEnum::Identifier,
                         value: String::from("John"),
                     },
                 },
                 reference: ReferenceLiteral {
                     chapter: NumberLiteral::new(1),
                     token: Token {
-                        t_type: TokenEnum::COLON,
+                        t_type: TokenEnum::Colon,
                         value: String::from(":"),
                     },
                     verses: vec![NumberLiteral::new(1)],
@@ -672,7 +677,7 @@ mod test {
         let expected = AstExpression::new(AstNode::NumberLiteral(NumberLiteral {
             value: 1,
             token: Token {
-                t_type: TokenEnum::NUMBER,
+                t_type: TokenEnum::Number,
                 value: String::from("1"),
             },
         }));
@@ -703,29 +708,33 @@ mod test {
         );
     }
 
-    #[test]
-    fn test_range_literal() {
-        let input = String::from("1-4");
-        let expected = AstExpression::new(AstNode::RangeLiteral(RangeLiteral {
+    fn range_test_data() -> AstExpression {
+        AstExpression::new(AstNode::RangeLiteral(RangeLiteral {
             start: NumberLiteral {
                 value: 1,
                 token: Token {
-                    t_type: TokenEnum::NUMBER,
+                    t_type: TokenEnum::Number,
                     value: String::from("1"),
                 },
             },
             end: NumberLiteral {
                 value: 4,
                 token: Token {
-                    t_type: TokenEnum::NUMBER,
+                    t_type: TokenEnum::Number,
                     value: String::from("4"),
                 },
             },
             token: Token {
-                t_type: TokenEnum::HYPHEN,
+                t_type: TokenEnum::Hyphen,
                 value: String::from("-"),
             },
-        }));
+        }))
+    }
+
+    #[test]
+    fn test_range_literal_with_through() {
+        let input = String::from("1 through 4");
+        let expected = range_test_data();
 
         let tokenizer = Tokenizer::new(input);
         let mut parser = Parser::new(tokenizer);
@@ -754,22 +763,117 @@ mod test {
     }
 
     #[test]
-    fn test_reference_literal() {
-        let input = String::from("3:3");
-        let expected = AstExpression::new(AstNode::ReferenceLiteral(ReferenceLiteral {
+    fn test_range_literal_with_to() {
+        let input = String::from("1 to 4");
+        let expected = range_test_data();
+
+        let tokenizer = Tokenizer::new(input);
+        let mut parser = Parser::new(tokenizer);
+        let stmts = parser.parse_program();
+
+        let expression = stmts.first().unwrap();
+        let ident = expression.get::<RangeLiteral>();
+        let tt = expected.get::<RangeLiteral>().unwrap();
+
+        // ==
+        assert!(ident.is_some(), "Expected RangeLiteral");
+
+        let ident = ident.unwrap();
+
+        assert_eq!(
+            tt.start, ident.start,
+            "expected [{:?}], got [{:?}]",
+            tt.start, ident.start,
+        );
+
+        assert_eq!(
+            ident.token.t_type, tt.token.t_type,
+            "expected [{:?}], got [{:?}]",
+            tt.token.t_type, ident.token.t_type
+        );
+    }
+
+    #[test]
+    fn test_range_literal() {
+        let input = String::from("1-4");
+        let expected = range_test_data();
+
+        let tokenizer = Tokenizer::new(input);
+        let mut parser = Parser::new(tokenizer);
+        let stmts = parser.parse_program();
+
+        let expression = stmts.first().unwrap();
+        let ident = expression.get::<RangeLiteral>();
+        let tt = expected.get::<RangeLiteral>().unwrap();
+
+        // ==
+        assert!(ident.is_some(), "Expected RangeLiteral");
+
+        let ident = ident.unwrap();
+
+        assert_eq!(
+            tt.start, ident.start,
+            "expected [{:?}], got [{:?}]",
+            tt.start, ident.start,
+        );
+
+        assert_eq!(
+            ident.token.t_type, tt.token.t_type,
+            "expected [{:?}], got [{:?}]",
+            tt.token.t_type, ident.token.t_type
+        );
+    }
+
+    fn reference_test_data() -> AstExpression {
+        AstExpression::new(AstNode::ReferenceLiteral(ReferenceLiteral {
             token: Token {
-                t_type: TokenEnum::COLON,
+                t_type: TokenEnum::Colon,
                 value: String::from(":"),
             },
             chapter: NumberLiteral {
                 value: 3,
                 token: Token {
-                    t_type: TokenEnum::NUMBER,
+                    t_type: TokenEnum::Number,
                     value: String::from("3"),
                 },
             },
             verses: vec![NumberLiteral::new(3)],
-        }));
+        }))
+    }
+
+    #[test]
+    fn test_reference_literal_chapter_tag() {
+        let input = String::from("chapter 3:3");
+        let expected = reference_test_data();
+
+        let tokenizer = Tokenizer::new(input);
+        let mut parser = Parser::new(tokenizer);
+        let stmts = parser.parse_program();
+        println!("{:?}", stmts);
+
+        let expression = stmts.first().unwrap();
+
+        _test_reference_literal(&expected, expression);
+    }
+    #[test]
+    fn test_reference_literal_words() {
+        let input = String::from("3 verse 3");
+        let expected = reference_test_data();
+
+        let tokenizer = Tokenizer::new(input);
+        let mut parser = Parser::new(tokenizer);
+        let stmts = parser.parse_program();
+        println!("{:?}", stmts);
+
+        let expression = stmts.first().unwrap();
+
+        _test_reference_literal(&expected, expression);
+    }
+
+    #[test]
+    fn test_reference_literal() {
+        let input = String::from("3:3");
+        let expected = reference_test_data();
 
         let tokenizer = Tokenizer::new(input);
         let mut parser = Parser::new(tokenizer);
@@ -814,21 +918,21 @@ mod test {
             AstExpression::new(AstNode::NumberLiteral(NumberLiteral {
                 value: 1,
                 token: Token {
-                    t_type: TokenEnum::NUMBER,
+                    t_type: TokenEnum::Number,
                     value: String::from("1"),
                 },
             })),
             AstExpression::new(AstNode::NumberLiteral(NumberLiteral {
                 value: 4,
                 token: Token {
-                    t_type: TokenEnum::NUMBER,
+                    t_type: TokenEnum::Number,
                     value: String::from("4"),
                 },
             })),
             AstExpression::new(AstNode::NumberLiteral(NumberLiteral {
                 value: 3,
                 token: Token {
-                    t_type: TokenEnum::NUMBER,
+                    t_type: TokenEnum::Number,
                     value: String::from("3"),
                 },
             })),
@@ -866,20 +970,20 @@ mod test {
 
     #[test]
     fn test_program() {
-        let input = String::from("1 John 1:1-3,5,7-10");
+        let input = String::from("1 John 1:1 to 3,5,7-10");
         let expected_list = [AstExpression::new(AstNode::AstReferenceLiteral(
             PassageLiteral {
                 book: Identifier {
                     prefix: Some(NumberLiteral::new(1)),
                     value: String::from("John"),
                     token: Token {
-                        t_type: TokenEnum::IDENTIFIER,
+                        t_type: TokenEnum::Identifier,
                         value: String::from("John"),
                     },
                 },
                 reference: ReferenceLiteral {
                     token: Token {
-                        t_type: TokenEnum::COLON,
+                        t_type: TokenEnum::Colon,
                         value: String::from(":"),
                     },
                     chapter: NumberLiteral::new(1),

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -474,7 +474,12 @@ fn parse_post_chapter(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpressi
         && p.peek_token.t_type != TokenEnum::Number
         && p.peek_token.t_type != TokenEnum::Comma
     {
-        return None;
+        let chapter = ReferenceLiteral {
+            token: p.current_token.clone(),
+            chapter: number_literal.clone(),
+            verses: vec![],
+        };
+        return Some(AstExpression::new(AstNode::ReferenceLiteral(chapter)));
     }
 
     // eg. Genesis 5, verse 4
@@ -495,21 +500,19 @@ fn parse_post_chapter(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpressi
         chapter: number_literal.clone(),
         verses,
     };
-
     Some(AstExpression::new(AstNode::ReferenceLiteral(chapter)))
 }
 
 fn parse_verse(p: &mut Parser) -> Option<Vec<NumberLiteral>> {
     if p.current_token.t_type != TokenEnum::Colon
-        && p.current_token.t_type != TokenEnum::Number
+    // this should be chapter number
+        && p.current_token.t_type != TokenEnum::Number 
         && p.current_token.t_type != TokenEnum::Comma
     {
         return None;
     }
 
-    if p.current_token.t_type == TokenEnum::Colon {
-        p.next_token();
-    }
+    p.next_token();
 
     let mut verses = Vec::new();
 
@@ -523,6 +526,7 @@ fn parse_verse(p: &mut Parser) -> Option<Vec<NumberLiteral>> {
 
     while p.current_token.t_type.ne(&TokenEnum::Eof)
         && p.current_token.t_type.ne(&TokenEnum::Semicolon)
+        && p.current_token.t_type.ne(&TokenEnum::Illegal)
     {
         if p.peek_token.t_type == TokenEnum::Identifier {
             break;
@@ -990,6 +994,90 @@ mod test {
 
         let stmt = stmts.first(); // identifier
         _test_passage_literal(0, expected_list.first().unwrap(), stmt.unwrap());
+    }
+
+    #[test]
+    fn test_program_simple() {
+        fn test_data() -> [AstExpression; 1] {
+            [AstExpression::new(AstNode::AstReferenceLiteral(
+                PassageLiteral {
+                    book: Identifier {
+                        prefix: None,
+                        value: String::from("James"),
+                        token: Token {
+                            t_type: TokenEnum::Identifier,
+                            value: String::from("James"),
+                        },
+                    },
+                    reference: ReferenceLiteral {
+                        token: Token {
+                            t_type: TokenEnum::Colon,
+                            value: String::from(":"),
+                        },
+                        chapter: NumberLiteral::new(1),
+                        verses: vec![NumberLiteral::new(17)],
+                    },
+                },
+            ))]
+        }
+
+        fn test_program_(input: &str) {
+            let expected_list = test_data();
+
+            let tokenizer = Tokenizer::new(input.into());
+            let mut parser = Parser::new(tokenizer);
+            let stmts = parser.parse_program();
+
+            let stmt = stmts.first(); // identifier
+            _test_passage_literal(0, expected_list.first().unwrap(), stmt.unwrap());
+        }
+
+        test_program_("James 1 17");
+        test_program_("James 1:17");
+        test_program_("James 1, 17");
+
+        test_program_("James 1 17 something here 5");
+        test_program_("James 1:17 something here 5");
+        test_program_("James 1, 17 something here 5");
+    }
+
+    #[test]
+    fn test_program_with_no_verses() {
+        fn test_data() -> [AstExpression; 1] {
+            [AstExpression::new(AstNode::AstReferenceLiteral(
+                PassageLiteral {
+                    book: Identifier {
+                        prefix: Some(NumberLiteral::new(1)),
+                        value: String::from("John"),
+                        token: Token {
+                            t_type: TokenEnum::Identifier,
+                            value: String::from("John"),
+                        },
+                    },
+                    reference: ReferenceLiteral {
+                        token: Token {
+                            t_type: TokenEnum::Colon,
+                            value: String::from(":"),
+                        },
+                        chapter: NumberLiteral::new(1),
+                        verses: vec![],
+                    },
+                },
+            ))]
+        }
+
+        fn test_program_(input: &str) {
+            let expected_list = test_data();
+
+            let tokenizer = Tokenizer::new(input.into());
+            let mut parser = Parser::new(tokenizer);
+            let stmts = parser.parse_program();
+
+            let stmt = stmts.first(); // identifier
+            _test_passage_literal(0, expected_list.first().unwrap(), stmt.unwrap());
+        }
+
+        test_program_("1 John 1");
     }
 
     #[test]

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -470,10 +470,19 @@ fn parse_post_identifier(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpre
 fn parse_post_chapter(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpression> {
     let number_literal = lhs.get::<NumberLiteral>()?;
 
-    if p.peek_token.t_type != TokenEnum::Colon && p.peek_token.t_type != TokenEnum::Number {
+    if p.peek_token.t_type != TokenEnum::Colon
+        && p.peek_token.t_type != TokenEnum::Number
+        && p.peek_token.t_type != TokenEnum::Comma
+    {
         return None;
     }
 
+    // eg. Genesis 5, verse 4
+    if p.peek_token.t_type == TokenEnum::Comma {
+        p.next_token();
+    }
+
+    // eg. Genesis 5:4
     if p.peek_token.t_type == TokenEnum::Colon {
         p.next_token();
     }
@@ -491,7 +500,6 @@ fn parse_post_chapter(p: &mut Parser, lhs: &AstExpression) -> Option<AstExpressi
 }
 
 fn parse_verse(p: &mut Parser) -> Option<Vec<NumberLiteral>> {
-    println!("{:?}", p.current_token);
     if p.current_token.t_type != TokenEnum::Colon && p.current_token.t_type != TokenEnum::Number {
         return None;
     }
@@ -555,6 +563,8 @@ fn parse_prefix_identifier(p: &mut Parser) -> Option<AstExpression> {
     if p.peek_token.t_type != TokenEnum::Number && p.peek_token.t_type != TokenEnum::Chapter {
         return None;
     }
+
+    // match text
 
     let ident = Identifier {
         token: p.current_token.clone(),
@@ -807,7 +817,6 @@ mod test {
         let tokenizer = Tokenizer::new(input);
         let mut parser = Parser::new(tokenizer);
         let stmts = parser.parse_program();
-        println!("{:?}", stmts);
 
         let expression = stmts.first().unwrap();
 
@@ -821,7 +830,6 @@ mod test {
         let tokenizer = Tokenizer::new(input);
         let mut parser = Parser::new(tokenizer);
         let stmts = parser.parse_program();
-        println!("{:?}", stmts);
 
         let expression = stmts.first().unwrap();
 
@@ -982,18 +990,18 @@ mod test {
     }
 
     #[test]
-    fn test_program_with_space() {
-        test_program_("1 John 1 1 to 3 5 7 through 10");
-        test_program_("1 John 1 1-3 5 7-10");
-        test_program_("1 John 1 1-3 and 5 and 7-10");
-        test_program_("1 John 1 1-3, 5, 7-10");
-    }
-
-    #[test]
     fn test_program() {
         test_program_("1 John 1:1 to 3,5,7-10");
         test_program_("1 John 1:1 to 3,5 and 7-10");
         test_program_("1 John 1:1 to 3 5 7 through 10");
+        test_program_("open to 1 John 1:1 to 3,5,7-10, lets read");
+        test_program_("open 1 John 1:1 to 3,5,7-10, lets read");
+        test_program_("1 John 1, verses 1 to 3,5,7-10, lets read");
+
         test_program_("1 John 1 1 to 3 5 7 through 10");
+        test_program_("1 John 1 1-3 5 7-10");
+        test_program_("1 John 1 1-3 and 5 and 7-10");
+        test_program_("1 John 1 1-3, 5, 7-10");
+        test_program_("1 John 1 verses 1 to 3 5 7 through 10");
     }
 }

--- a/src/parser/tokenizer.rs
+++ b/src/parser/tokenizer.rs
@@ -1,17 +1,16 @@
-use std::usize;
-
 use gtk::glib::char;
 
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Copy)]
 pub enum TokenEnum {
-    NUMBER,
-    IDENTIFIER,
-    COLON,
-    SEMICOLON,
-    HYPHEN,
-    COMMA,
-    ILLEGAL,
-    EOF,
+    Number,
+    Identifier,
+    Colon,
+    Semicolon,
+    Chapter,
+    Hyphen,
+    Comma,
+    Illegal,
+    Eof,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -21,6 +20,9 @@ pub struct Token {
 }
 
 impl Token {
+    fn new(t_type: TokenEnum, value: String) -> Self {
+        Self { t_type, value }
+    }
     pub fn inspect(&self) -> String {
         self.value.clone()
     }
@@ -53,19 +55,19 @@ impl Tokenizer {
 
         let token = match self.char {
             ':' => Token {
-                t_type: TokenEnum::COLON,
+                t_type: TokenEnum::Colon,
                 value: String::from(":"),
             },
             ';' => Token {
-                t_type: TokenEnum::SEMICOLON,
+                t_type: TokenEnum::Semicolon,
                 value: String::from(";"),
             },
             '-' => Token {
-                t_type: TokenEnum::HYPHEN,
+                t_type: TokenEnum::Hyphen,
                 value: String::from("-"),
             },
             ',' => Token {
-                t_type: TokenEnum::COMMA,
+                t_type: TokenEnum::Comma,
                 value: String::from(","),
             },
 
@@ -73,17 +75,20 @@ impl Tokenizer {
             // handle EOF
             // ===
             '\0' => Token {
-                t_type: TokenEnum::EOF,
+                t_type: TokenEnum::Eof,
                 value: String::from('\0'),
             },
 
             ch => {
                 if Tokenizer::is_letter(ch) {
                     // read string
-                    let str = self.read_string();
-                    return Token {
-                        t_type: TokenEnum::IDENTIFIER,
-                        value: str,
+                    let text = self.read_string();
+
+                    return match text.to_lowercase().as_str() {
+                        "chapter" => Token::new(TokenEnum::Chapter, text),
+                        "verse" | "verses" => Token::new(TokenEnum::Colon, text),
+                        "to" | "through" => Token::new(TokenEnum::Hyphen, text),
+                        _ => Token::new(TokenEnum::Identifier, text),
                     };
                 }
 
@@ -91,14 +96,14 @@ impl Tokenizer {
                     // read digit
                     let num = self.read_digit();
                     return Token {
-                        t_type: TokenEnum::NUMBER,
+                        t_type: TokenEnum::Number,
                         value: num,
                     };
                 }
 
                 Token {
                     value: String::from(self.char),
-                    t_type: TokenEnum::ILLEGAL,
+                    t_type: TokenEnum::Illegal,
                 }
             }
         };
@@ -171,147 +176,59 @@ mod test {
             1 John 1:3-1
             1 John 1:1,3
             1 John 1:1-3,5;
+            John chapter 1 verse 3
+            to through
             "#,
         );
 
         let expected = vec![
             // 1
-            Token {
-                value: "John".to_string(),
-                t_type: TokenEnum::IDENTIFIER,
-            },
-            Token {
-                value: "1".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: ":".to_string(),
-                t_type: TokenEnum::COLON,
-            },
-            Token {
-                value: "3".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
+            Token::new(TokenEnum::Identifier, "John".to_string()),
+            Token::new(TokenEnum::Number, "1".to_string()),
+            Token::new(TokenEnum::Colon, ":".to_string()),
+            Token::new(TokenEnum::Number, "3".to_string()),
             // 2
-            Token {
-                value: "1".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: "John".to_string(),
-                t_type: TokenEnum::IDENTIFIER,
-            },
-            Token {
-                value: "1".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: ":".to_string(),
-                t_type: TokenEnum::COLON,
-            },
-            Token {
-                value: "3".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
+            Token::new(TokenEnum::Number, "1".to_string()),
+            Token::new(TokenEnum::Identifier, "John".to_string()),
+            Token::new(TokenEnum::Number, "1".to_string()),
+            Token::new(TokenEnum::Colon, ":".to_string()),
+            Token::new(TokenEnum::Number, "3".to_string()),
             // 3
-            Token {
-                value: "1".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: "John".to_string(),
-                t_type: TokenEnum::IDENTIFIER,
-            },
-            Token {
-                value: "1".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: ":".to_string(),
-                t_type: TokenEnum::COLON,
-            },
-            Token {
-                value: "3".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: "-".to_string(),
-                t_type: TokenEnum::HYPHEN,
-            },
-            Token {
-                value: "1".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
+            Token::new(TokenEnum::Number, "1".to_string()),
+            Token::new(TokenEnum::Identifier, "John".to_string()),
+            Token::new(TokenEnum::Number, "1".to_string()),
+            Token::new(TokenEnum::Colon, ":".to_string()),
+            Token::new(TokenEnum::Number, "3".to_string()),
+            Token::new(TokenEnum::Hyphen, "-".to_string()),
+            Token::new(TokenEnum::Number, "1".to_string()),
             // 4
-            Token {
-                value: "1".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: "John".to_string(),
-                t_type: TokenEnum::IDENTIFIER,
-            },
-            Token {
-                value: "1".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: ":".to_string(),
-                t_type: TokenEnum::COLON,
-            },
-            Token {
-                value: "1".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: ",".to_string(),
-                t_type: TokenEnum::COMMA,
-            },
-            Token {
-                value: "3".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
+            Token::new(TokenEnum::Number, "1".to_string()),
+            Token::new(TokenEnum::Identifier, "John".to_string()),
+            Token::new(TokenEnum::Number, "1".to_string()),
+            Token::new(TokenEnum::Colon, ":".to_string()),
+            Token::new(TokenEnum::Number, "1".to_string()),
+            Token::new(TokenEnum::Comma, ",".to_string()),
+            Token::new(TokenEnum::Number, "3".to_string()),
             // 5
-            Token {
-                value: "1".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: "John".to_string(),
-                t_type: TokenEnum::IDENTIFIER,
-            },
-            Token {
-                value: "1".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: ":".to_string(),
-                t_type: TokenEnum::COLON,
-            },
-            Token {
-                value: "1".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: "-".to_string(),
-                t_type: TokenEnum::HYPHEN,
-            },
-            Token {
-                value: "3".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: ",".to_string(),
-                t_type: TokenEnum::COMMA,
-            },
-            Token {
-                value: "5".to_string(),
-                t_type: TokenEnum::NUMBER,
-            },
-            Token {
-                value: ";".to_string(),
-                t_type: TokenEnum::SEMICOLON,
-            },
+            Token::new(TokenEnum::Number, "1".to_string()),
+            Token::new(TokenEnum::Identifier, "John".to_string()),
+            Token::new(TokenEnum::Number, "1".to_string()),
+            Token::new(TokenEnum::Colon, ":".to_string()),
+            Token::new(TokenEnum::Number, "1".to_string()),
+            Token::new(TokenEnum::Hyphen, "-".to_string()),
+            Token::new(TokenEnum::Number, "3".to_string()),
+            Token::new(TokenEnum::Comma, ",".to_string()),
+            Token::new(TokenEnum::Number, "5".to_string()),
+            Token::new(TokenEnum::Semicolon, ";".to_string()),
+            // 6
+            Token::new(TokenEnum::Identifier, "John".to_string()),
+            Token::new(TokenEnum::Chapter, "chapter".to_string()),
+            Token::new(TokenEnum::Number, "1".to_string()),
+            Token::new(TokenEnum::Colon, "verse".to_string()),
+            Token::new(TokenEnum::Number, "3".to_string()),
+            // 7
+            Token::new(TokenEnum::Hyphen, "to".to_string()),
+            Token::new(TokenEnum::Hyphen, "through".to_string()),
         ];
 
         let mut lexer = Tokenizer::new(input);

--- a/src/parser/tokenizer.rs
+++ b/src/parser/tokenizer.rs
@@ -88,6 +88,7 @@ impl Tokenizer {
                         "chapter" => Token::new(TokenEnum::Chapter, text),
                         "verse" | "verses" => Token::new(TokenEnum::Colon, text),
                         "to" | "through" => Token::new(TokenEnum::Hyphen, text),
+                        "and" => Token::new(TokenEnum::Comma, text),
                         _ => Token::new(TokenEnum::Identifier, text),
                     };
                 }
@@ -177,7 +178,7 @@ mod test {
             1 John 1:1,3
             1 John 1:1-3,5;
             John chapter 1 verse 3
-            to through
+            to through and
             "#,
         );
 
@@ -229,6 +230,7 @@ mod test {
             // 7
             Token::new(TokenEnum::Hyphen, "to".to_string()),
             Token::new(TokenEnum::Hyphen, "through".to_string()),
+            Token::new(TokenEnum::Comma, "and".to_string()),
         ];
 
         let mut lexer = Tokenizer::new(input);

--- a/src/parser/tokenizer.rs
+++ b/src/parser/tokenizer.rs
@@ -1,5 +1,64 @@
 use gtk::glib::char;
 
+const BIBLE_BOOK_IDENTIFIERS: [&str; 56] = [
+    "genesis",
+    "exodus",
+    "leviticus",
+    "numbers",
+    "deuteronomy",
+    "joshua",
+    "judges",
+    "ruth",
+    "samuel",
+    "kings",
+    "chronicles",
+    "ezra",
+    "nehemiah",
+    "esther",
+    "job",
+    "psalms",
+    "proverbs",
+    "ecclesiastes",
+    "song of solomon",
+    "isaiah",
+    "jeremiah",
+    "lamentations",
+    "ezekiel",
+    "daniel",
+    "hosea",
+    "joel",
+    "amos",
+    "obadiah",
+    "jonah",
+    "micah",
+    "nahum",
+    "habakkuk",
+    "zephaniah",
+    "haggai",
+    "zechariah",
+    "malachi",
+    "matthew",
+    "mark",
+    "luke",
+    "john",
+    "acts",
+    "romans",
+    "corinthians",
+    "galatians",
+    "ephesians",
+    "philippians",
+    "colossians",
+    "thessalonians",
+    "timothy",
+    "titus",
+    "philemon",
+    "hebrews",
+    "james",
+    "peter",
+    "jude",
+    "revelation",
+];
+
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Copy)]
 pub enum TokenEnum {
     Number,
@@ -89,7 +148,10 @@ impl Tokenizer {
                         "verse" | "verses" => Token::new(TokenEnum::Colon, text),
                         "to" | "through" => Token::new(TokenEnum::Hyphen, text),
                         "and" => Token::new(TokenEnum::Comma, text),
-                        _ => Token::new(TokenEnum::Identifier, text),
+                        s if BIBLE_BOOK_IDENTIFIERS.contains(&text.to_lowercase().as_str()) => {
+                            Token::new(TokenEnum::Identifier, text)
+                        }
+                        _ => Token::new(TokenEnum::Illegal, text),
                     };
                 }
 
@@ -179,6 +241,7 @@ mod test {
             1 John 1:1-3,5;
             John chapter 1 verse 3
             to through and
+            rubish
             "#,
         );
 
@@ -231,6 +294,7 @@ mod test {
             Token::new(TokenEnum::Hyphen, "to".to_string()),
             Token::new(TokenEnum::Hyphen, "through".to_string()),
             Token::new(TokenEnum::Comma, "and".to_string()),
+            Token::new(TokenEnum::Illegal, "rubish".to_string()),
         ];
 
         let mut lexer = Tokenizer::new(input);

--- a/src/services/slide.rs
+++ b/src/services/slide.rs
@@ -331,19 +331,19 @@ impl Slide {
     }
 
     pub fn entry_buffer(&self) -> Option<gtk::TextBuffer> {
-        if let Some(canvas) = self.canvas() {
-            for t in canvas.widget().get_children::<TextItem>() {
-                return Some(t.buffer().clone());
-            }
+        if let Some(canvas) = self.canvas()
+            && let Some(t) = canvas.widget().get_children::<TextItem>().next()
+        {
+            return Some(t.buffer().clone());
         }
 
         None
     }
     pub fn text_item(&self) -> Option<TextItem> {
-        if let Some(canvas) = self.canvas() {
-            for t in canvas.widget().get_children::<TextItem>() {
-                return Some(t);
-            }
+        if let Some(canvas) = self.canvas()
+            && let Some(t) = canvas.widget().get_children::<TextItem>().next()
+        {
+            return Some(t);
         }
 
         None

--- a/src/widgets/settings_window.rs
+++ b/src/widgets/settings_window.rs
@@ -1,7 +1,7 @@
 use gtk::{gio, glib};
 
 mod imp {
-    use std::{cell::RefCell, collections::HashMap, usize};
+    use std::{cell::RefCell, collections::HashMap};
 
     use gtk::{
         gdk::{
@@ -212,7 +212,7 @@ mod imp {
     impl SettingsWindow {
         fn get_fonts(&self) -> Vec<String> {
             let font_map = self.fonts_map.borrow().clone();
-            let mut fonts = font_map.keys().map(|v| v.clone()).collect::<Vec<_>>();
+            let mut fonts = font_map.keys().cloned().collect::<Vec<_>>();
             fonts.sort();
             fonts
         }
@@ -335,10 +335,8 @@ mod imp {
                 gtk::ClosureExpression::new::<Option<String>>(
                     gtk::Expression::NONE,
                     glib::closure_local!(move |item: glib::Object| {
-                        match item.downcast_ref::<IntegerObject>() {
-                            Some(item) => Some(item.number().to_string()),
-                            None => None,
-                        }
+                        item.downcast_ref::<IntegerObject>()
+                            .map(|item| item.number().to_string())
                     }),
                 ),
             ));
@@ -435,7 +433,7 @@ mod imp {
                             .position(|v| *v == font)
                             .unwrap_or_default() as u32;
 
-                        Some((found as u32).to_value())
+                        Some(found.to_value())
                     }
                 ))
                 .set_mapping(glib::clone!(
@@ -445,9 +443,7 @@ mod imp {
                         let selected: u32 =
                             font.get().expect("The variant needs to be of type `i32`.");
 
-                        let Some(font) = font_names.get(selected as usize) else {
-                            return None;
-                        };
+                        let font = font_names.get(selected as usize)?;
                         Some(font.to_variant())
                     }
                 ))
@@ -469,7 +465,7 @@ mod imp {
                             .position(|v| *v == font)
                             .unwrap_or_default() as u32;
 
-                        Some((found as u32).to_value())
+                        Some(found.to_value())
                     }
                 ))
                 .set_mapping(glib::clone!(
@@ -479,9 +475,7 @@ mod imp {
                         let selected: u32 =
                             font.get().expect("The variant needs to be of type `i32`.");
 
-                        let Some(font) = font_names.get(selected as usize) else {
-                            return None;
-                        };
+                        let font = font_names.get(selected as usize)?;
                         Some(font.to_variant())
                     }
                 ))


### PR DESCRIPTION
This commit adds new keywords to bible reference parser:
- chapter: chapter marker
- verse, versers: verse marker (same as colon)
- to, through: range marker (same as hyphen)

this will help with future search intergration that may come from
transcription and other actions